### PR TITLE
Change class description in \ProvidesClass optional argument

### DIFF
--- a/rub-kunstgeschichte/rub-kunstgeschichte.dtx
+++ b/rub-kunstgeschichte/rub-kunstgeschichte.dtx
@@ -29,7 +29,7 @@
 %<class>\NeedsTeXFormat{LaTeX2e}[2022-06-01]
 %<class>\ProvidesClass{rub-kunstgeschichte}
 %<*class>
-    [2024-05-26 v0.1.0 RUB KGI class]
+    [2024-05-26 v0.1.0 RUB Kunstgeschichte class]
 %</class>
 %<*driver>
 \documentclass{ltxdoc}


### PR DESCRIPTION
Change class description in \ProvidesClass optional argument
to be consistent with the renaming from rub-kgi to rub-kunstgeschichte.