### PR TITLE
Change release workflow to be triggered by release PR

### DIFF
--- a/.github/actions/get-release-version/action.yaml
+++ b/.github/actions/get-release-version/action.yaml
@@ -1,0 +1,22 @@
+name: 'Get release version'
+description: 'Gets the most recent release version from the .dtx file'
+inputs:
+  file:
+    description: 'path to the .dtx file to search for the release version'
+    required: true
+  class-name:
+    description: 'name or regex pattern to match for the class name to look for'
+    default: '.*'
+outputs:
+  current-version:
+    description: 'The current release version'
+    value: ${{ steps.get_current_version.outputs.current-version }}
+runs:
+  using: "composite"
+  steps:
+    - id: get_current_version
+      run: |
+        CURRENT_VERSION=$(grep -Pzo '\\ProvidesClass\{${{ inputs.class-name }}\}(.|\n)*?\[\d{4}-\d{2}-\d{2} v\K\d+\.\d+\.\d+' ${{ inputs.file }} | tr '\0' '\n')
+        echo "found version: $CURRENT_VERSION"
+        echo "current-version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+      shell: bash

--- a/.github/actions/get-release-version/action.yaml
+++ b/.github/actions/get-release-version/action.yaml
@@ -8,15 +8,15 @@ inputs:
     description: 'name or regex pattern to match for the class name to look for'
     default: '.*'
 outputs:
-  current-version:
-    description: 'The current release version'
-    value: ${{ steps.get_current_version.outputs.current-version }}
+  version:
+    description: 'The release version'
+    value: ${{ steps.get_version.outputs.version }}
 runs:
   using: "composite"
   steps:
-    - id: get_current_version
+    - id: get_version
       run: |
-        CURRENT_VERSION=$(grep -Pzo '\\ProvidesClass\{${{ inputs.class-name }}\}(.|\n)*?\[\d{4}-\d{2}-\d{2} v\K\d+\.\d+\.\d+' ${{ inputs.file }} | tr '\0' '\n')
-        echo "found version: $CURRENT_VERSION"
-        echo "current-version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+        VERSION=$(grep -Pzo '\\ProvidesClass\{${{ inputs.class-name }}\}(.|\n)*?\[\d{4}-\d{2}-\d{2} v\K\d+\.\d+\.\d+' ${{ inputs.file }} | tr '\0' '\n')
+        echo "found version: $VERSION"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,13 +1,16 @@
 name: Create release
 
 on:
-  push:
-    tags:
-      - "v*"
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.title, 'Release:') && startsWith(github.head_ref, 'release/')
     container: registry.gitlab.com/islandoftex/images/texlive:TL2024-2024-05-19-full
     permissions:
       contents: write
@@ -15,6 +18,12 @@ jobs:
       # Check out the repository
       - name: Checkout repository
         uses: actions/checkout@v4
+      # Set up Git as github-actions bot
+      - name: Set up Git
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
 
       # Run automated testing
       # extract files from dtx
@@ -24,10 +33,25 @@ jobs:
         run: l3build ctan -q -H
         working-directory: ./rub-kunstgeschichte
 
+      # Create tag with the new version
+      - name: Get new version number
+        id: get_new_version
+        uses: ./.github/actions/get-release-version
+        with:
+          file: ./rub-kunstgeschichte/rub-kunstgeschichte.dtx
+          class-name: rub-kunstgeschichte
+      - name: Tag the commit
+        run: |
+          next_version=${{ steps.get_new_version.outputs.version }}
+          git tag -a "$next_version" -m "$Version next_version. See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details."
+          git push --follow-tags
+
       # Create a GitHub release
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.get_new_version.outputs.version }}
+          name: Release ${{ steps.get_new_version.outputs.version }}
           files: |
             rub-kunstgeschichte/build/unpacked/rub-kunstgeschichte.cls
             rub-kunstgeschichte/build/distrib/**/*.zip

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,24 +33,26 @@ jobs:
         run: l3build ctan -q -H
         working-directory: ./rub-kunstgeschichte
 
-      # Create tag with the new version
+      # Get new version
       - name: Get new version number
         id: get_new_version
         uses: ./.github/actions/get-release-version
         with:
           file: ./rub-kunstgeschichte/rub-kunstgeschichte.dtx
           class-name: rub-kunstgeschichte
-      - name: Tag the commit
-        run: |
-          next_version=${{ steps.get_new_version.outputs.version }}
-          git tag -a "$next_version" -m "$Version next_version. See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details."
-          git push --follow-tags
 
       # Extract release notes from CHANGELOG.md
       - name: Extract release notes
         id: extract_release_notes
         run: |
           sed -n '/^## \[${{ steps.get_new_version.outputs.version }}\]/,/^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ { /^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ !p; }' CHANGELOG.md > release_notes.md
+
+      # Tag new version
+      - name: Tag the commit
+        run: |
+          next_version=${{ steps.get_new_version.outputs.version }}
+          git tag -a "$next_version" -m "Version $next_version. See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details."
+          git push --follow-tags
 
       # Create a GitHub release
       - name: Release

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,16 +53,19 @@ jobs:
 
       # Tag new version
       - name: Tag the commit
+        id: tag_commit
         run: |
           next_version=${{ steps.get_new_version.outputs.version }}
-          git tag -a "$next_version" -m "Version $next_version. See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details."
+          tag_name=v$next_version
+          git tag -a "$tag_name" -m "Version $next_version."
           git push --follow-tags
+          echo "tag-name=$tag_name" >> "$GITHUB_OUTPUT"
 
       # Create a GitHub release
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.get_new_version.outputs.version }}
+          tag_name: ${{ steps.tag_commit.outputs.tag-name }}
           name: Release ${{ steps.get_new_version.outputs.version }}
           body_path: ./release_notes.md
           files: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,12 +46,21 @@ jobs:
           git tag -a "$next_version" -m "$Version next_version. See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details."
           git push --follow-tags
 
+      # Extract release notes from CHANGELOG.md
+      - name: Extract release notes
+        id: extract_release_notes
+        run: |
+          RELEASE_NOTES_PATH=${{ github.workspace }}/release_notes.md
+          sed -n '/^## \[${{ steps.get_new_version.outputs.version }}\]/,/^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ { /^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ !p; }' CHANGELOG.md > $RELEASE_NOTES_PATH
+          echo "release-notes-path=$RELEASE_NOTES_PATH" >> "$GITHUB_OUTPUT"
+
       # Create a GitHub release
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_new_version.outputs.version }}
           name: Release ${{ steps.get_new_version.outputs.version }}
+          body_path: ${{ steps.extract_release_notes.outputs.release-notes-path }}
           files: |
             rub-kunstgeschichte/build/unpacked/rub-kunstgeschichte.cls
             rub-kunstgeschichte/build/distrib/**/*.zip

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,8 +48,7 @@ jobs:
       # Extract release notes from CHANGELOG.md
       - name: Extract release notes
         id: extract_release_notes
-        run: |
-          sed -n '/^## \[${{ steps.get_new_version.outputs.version }}\]/,/^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ { /^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ !p; }' CHANGELOG.md > release_notes.md
+        run: sed -n '/^## \[v0.2.0\]/,/^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ { /^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ !p; }' CHANGELOG.md | tee release_notes.md
 
       # Tag new version
       - name: Tag the commit

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,7 +34,7 @@ jobs:
           image: registry.gitlab.com/islandoftex/images/texlive:TL2024-2024-05-19-full
           options: -v ${{ github.workspace }}/rub-kunstgeschichte:/workspace
           run: |
-            cd rub-kunstgeschichte
+            cd /workspace
             l3build ctan -q -H
 
       # Get new version

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Create release
+name: Automatically create release
 
 on:
   pull_request:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -50,9 +50,7 @@ jobs:
       - name: Extract release notes
         id: extract_release_notes
         run: |
-          RELEASE_NOTES_PATH=${{ github.workspace }}/release_notes.md
-          sed -n '/^## \[${{ steps.get_new_version.outputs.version }}\]/,/^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ { /^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ !p; }' CHANGELOG.md > $RELEASE_NOTES_PATH
-          echo "release-notes-path=$RELEASE_NOTES_PATH" >> "$GITHUB_OUTPUT"
+          sed -n '/^## \[${{ steps.get_new_version.outputs.version }}\]/,/^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ { /^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ !p; }' CHANGELOG.md > release_notes.md
 
       # Create a GitHub release
       - name: Release
@@ -60,7 +58,7 @@ jobs:
         with:
           tag_name: ${{ steps.get_new_version.outputs.version }}
           name: Release ${{ steps.get_new_version.outputs.version }}
-          body_path: ${{ steps.extract_release_notes.outputs.release-notes-path }}
+          body_path: ./release_notes.md
           files: |
             rub-kunstgeschichte/build/unpacked/rub-kunstgeschichte.cls
             rub-kunstgeschichte/build/distrib/**/*.zip

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.event.pull_request.title, 'Release:') && startsWith(github.head_ref, 'release/')
-    container: registry.gitlab.com/islandoftex/images/texlive:TL2024-2024-05-19-full
     permissions:
       contents: write
     steps:
@@ -30,8 +29,13 @@ jobs:
       # build documentation
       # and package a .zip for ctan
       - name: Run l3build
-        run: l3build ctan -q -H
-        working-directory: ./rub-kunstgeschichte
+        uses: addnab/docker-run-action@v3
+        with:
+          image: registry.gitlab.com/islandoftex/images/texlive:TL2024-2024-05-19-full
+          options: -v ${{ github.workspace }}/rub-kunstgeschichte:/workspace
+          run: |
+            cd rub-kunstgeschichte
+            l3build ctan -q -H
 
       # Get new version
       - name: Get new version number

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    if: github.ref != 'refs/heads/main'
     steps:
       # Check out the repository
       - name: Checkout repository

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Extract MAJOR, MINOR and PATCH version numbers
         id: extract_major_minor_patch
         env:
-          VERSION_FULL: ${{ steps.get_current_version.outputs.current-version }}
+          VERSION_FULL: ${{ steps.get_current_version.outputs.version }}
         run: |
           echo "version_major=$(echo $VERSION_FULL | grep -Po '^\d+')" >> "$GITHUB_OUTPUT"
           echo "version_minor=$(echo $VERSION_FULL | grep -Po '^\d+\.\K\d+')" >> "$GITHUB_OUTPUT"
@@ -99,7 +99,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCH: release/${{ steps.calculate_new_version.outputs.new_version }}
           PR_TITLE: "Release: ${{ steps.calculate_new_version.outputs.new_version }} Pull Request"
-          PR_BODY: "This pull request contains the version bump from ${{ steps.get_current_version.outputs.current-version }} to ${{ steps.calculate_new_version.outputs.new_version }}. It was created automatically in the '${{ github.workflow }}' workflow triggered by @${{ github.triggering_actor }}."
+          PR_BODY: "This pull request contains the version bump from ${{ steps.get_current_version.outputs.version }} to ${{ steps.calculate_new_version.outputs.new_version }}. It was created automatically in the '${{ github.workflow }}' workflow triggered by @${{ github.triggering_actor }}."
       # Summarize results
       - name: Summarize job
         env:

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -32,13 +32,14 @@ jobs:
       # Update version number
       - name: Get current version number
         id: get_current_version
-        working-directory: ./rub-kunstgeschichte
-        run: |
-          echo "current_version=$(grep -Pzo '\\ProvidesClass\{rub-kunstgeschichte\}(.|\n)*?\[\d{4}-\d{2}-\d{2} v\K\d+\.\d+\.\d+' rub-kunstgeschichte.dtx | tr '\0' '\n')" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/get-release-version
+        with:
+          file: ./rub-kunstgeschichte/rub-kunstgeschichte.dtx
+          class-name: rub-kunstgeschichte
       - name: Extract MAJOR, MINOR and PATCH version numbers
         id: extract_major_minor_patch
         env:
-          VERSION_FULL: ${{ steps.get_current_version.outputs.current_version }}
+          VERSION_FULL: ${{ steps.get_current_version.outputs.current-version }}
         run: |
           echo "version_major=$(echo $VERSION_FULL | grep -Po '^\d+')" >> "$GITHUB_OUTPUT"
           echo "version_minor=$(echo $VERSION_FULL | grep -Po '^\d+\.\K\d+')" >> "$GITHUB_OUTPUT"
@@ -97,7 +98,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCH: release/${{ steps.calculate_new_version.outputs.new_version }}
           PR_TITLE: "Release: ${{ steps.calculate_new_version.outputs.new_version }} Pull Request"
-          PR_BODY: "This pull request contains the version bump from ${{ steps.get_current_version.outputs.CURRENT_VERSION }} to ${{ steps.calculate_new_version.outputs.new_version }}. It was created automatically in the '${{ github.workflow }}' workflow triggered by @${{ github.triggering_actor }}."
+          PR_BODY: "This pull request contains the version bump from ${{ steps.get_current_version.outputs.current-version }} to ${{ steps.calculate_new_version.outputs.new_version }}. It was created automatically in the '${{ github.workflow }}' workflow triggered by @${{ github.triggering_actor }}."
       # Summarize results
       - name: Summarize job
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+release_notes.md
+
 # compiled files
 out
 


### PR DESCRIPTION
- Changes the release workflow to be triggered by the release PR instead of a tag push.
- Release tags are automatically created
- Release notes are extracted from the CHANGELOG.md