### PR TITLE
Printing divided bibliographies and translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Print bibliographies divided into primary and secondary literature with **\printbibliographies**
+- Translation support using the [translations](https://ctan.org/pkg/translations) package
+
 ### Changed
 
 - Use [arthistory-bonn](https://ctan.org/pkg/biblatex-arthistory-bonn) biblatex style instead of [authortitle-dw](https://ctan.org/pkg/biblatex-dw)

--- a/rub-kunstgeschichte/rub-kunstgeschichte.dtx
+++ b/rub-kunstgeschichte/rub-kunstgeschichte.dtx
@@ -60,6 +60,8 @@
 % \DoNotIndex{\section,\subsection,\subsubsection}
 % \DoNotIndex{\title,\author,\tableofcontents}
 % \DoNotIndex{\LaTeX,\verb}
+% \DoNotIndex{\texorpdfstring}
+% \DoNotIndex{\@rubkgi@bibheading,\@rubkgi@bibheading@primary,\@rubkgi@bibheading@secondary}
 %
 %^^A define helper commands for consistent typesetting in the documentation
 % \DeclareDocumentCommand\email{m}{\href{mailto:#1}{\nolinkurl{#1}}}
@@ -150,7 +152,8 @@
 %
 % \subsection{Macros}\label{sec:usage:macros}
 %
-% \DescribeMacro{\printbibliographies}
+% \DescribeMacro{\printbibliographies} \oarg{options}
+%
 % Prints the bibliography, divided into two subbibliographies.
 % One for primary sources and one for secondary literature, as suggested in section 3.7.1 of the guidelines on page 14.
 % It uses the keyword mechanism to distinguish primary sources i.e. in order for a bib entry to be sorted into the primary sources section, it needs the \texttt{source} keyword.
@@ -164,6 +167,20 @@
 % }
 % \end{sourceverb}
 % All other entries which don't have the \texttt{source} keyword will be sorted into the secondary literature section of the bibliography.
+%
+% You can customize the behavior of the macro using key-value \meta{options}. The option keys that are currently available are \optn{heading}, \optn{heading-primary} and \optn{heading-secondary} to overwrite the headings of the bibliography and the two subbibliographies respectively.
+%
+% \subsection{Translations}\label{sec:usage:translations}
+%
+% The class uses the \pkg{translations} package to allow multi-lingual strings. The default language is english. To tell it which language it should use, you can load a package like \pkg{babel} with the corresponding language as the package option in the preamble. E.g. for german using the new spelling rules
+% \begin{sourceverb}
+% \usepackage[ngerman]{babel}
+% \end{sourceverb}
+%
+% All pre-defined strings this class prints on the page of the document (such as the headings of the bibliographies when using \cs{printbibliographies}) are available in multiple languages.
+% So far this package only defines its strings for english and german, but you can define them for other languages too.\footnote{E.g. using the \cs{declaretranslation} command. For more info, refer to the documentation of the \pkg{translations} package: \url{https://ctan.org/pkg/translations}}
+%
+% The translation string definitions can be found in \autoref{sec:implementation:translations}.
 %
 % \StopEventually{}
 %
@@ -400,31 +417,90 @@
 \hypersetup{hidelinks=true}
 %    \end{macrocode}
 %
+% \DescribePackage{translations}
+% Used internally by the class to create multilingual strings that react to the document language set e.g. by \pkg{babel}.
+% \iffalse
+%% Translations
+% \fi
+%    \begin{macrocode}
+\RequirePackage{translations}
+%    \end{macrocode}
+%
 % \subsection{Macros}\label{sec:implementation:macros}
+% \iffalse
+%% Macros
+% \fi
 %
 % \begin{macro}{\printbibliographies}
 % \changes{unreleased}{unreleased}{was added}^^A
 % Prints the bibliography using the native \cs{printbibliography} macro, but divides it into sections for primary sources and secondary literature. The keyword \texttt{source} is used to sort entries into the primary sources section.
+%
+% We start by defining the macro with an optional argument that is passed to \cs{SetKeys} to allow customization using key-value pairs.
 %    \begin{macrocode}
-\newcommand{\printbibliographies}{%
-    \addcontentsline{toc}{section}{\refname}%
+\newcommand{\printbibliographies}[1][]{%
+    \SetKeys[rubkgi@printbibliographies]{#1}%
+%    \end{macrocode}
+% We add an entry to the table of contents and insert the main bibliography heading.
+%    \begin{macrocode}
+    \addcontentsline{toc}{section}{%
+        \texorpdfstring{\@rubkgi@bibheading}{bibliography}%
+    }%
     \printbibheading[%
         heading = bibliography,%
-        title = {\refname}%
+        title = {\@rubkgi@bibheading}%
     ]
+%    \end{macrocode}
+% Then we print the subbibliographies.
+%    \begin{macrocode}
     \printbibliography[%
         keyword = source,%
         heading = subbibliography,%
-        title = {Primary sources}%
+        title = {\@rubkgi@bibheading@primary}%
     ]
     \printbibliography[%
         notkeyword = source,%
         heading = subbibliography,%
-        title = {Secondary literature}%
+        title = {\@rubkgi@bibheading@secondary}%
     ]
 }
 %    \end{macrocode}
+% For greater flexibility we define the heading strings as internal macros that can be redefined by the user with key-value options and use the \pkg{translations} package for the default strings. See \autoref{sec:implementation:translations} for the implementation of the translations. We don't want heading strings to include paragraphs, this is why we use the starred variant of \cs{newcommand}.
+%    \begin{macrocode}
+\newcommand*{\@rubkgi@bibheading}{
+    \GetTranslationWarn{Bibliography}
+}
+\newcommand*{\@rubkgi@bibheading@primary}{
+    \GetTranslationWarn{Primary Bibliography}
+}
+\newcommand*{\@rubkgi@bibheading@secondary}{
+    \GetTranslationWarn{Secondary Bibliography}
+}
+%    \end{macrocode}
+% Finally, we declare the keys that the user can use to redefine the headings.
+%    \begin{macrocode}
+\DeclareKeys[rubkgi@printbibliographies]
+{
+    heading           .store = \@rubkgi@bibheading,
+    heading-primary   .store = \@rubkgi@bibheading@primary,
+    heading-secondary .store = \@rubkgi@bibheading@secondary
+}
+%    \end{macrocode}
 % \end{macro}
+%
+% \subsection{Translations}\label{sec:implementation:translations}
+% \changes{unreleased}{unreleased}{Use translations package for multi-lingual support.}^^A
+%
+% The \pkg{translations} package offers an easy interface to create multilingual strings. We can define them all at once here, at the end of the class, since they are only used when the user commands are expanded in the document.
+%
+% \subsubsection*{Bibliography headings}
+%
+% The \pkg{translations} package already comes with translations for the main heading of the bibliography. Additionally, we provide the headings for the subbibliographies in english and german.
+%    \begin{macrocode}
+\DeclareTranslation{english}{Primary Bibliography}{Primary sources}
+\DeclareTranslation{german}{Primary Bibliography}{Primärliteratur}
+\DeclareTranslation{english}{Secondary Bibliography}{Secondary literature}
+\DeclareTranslation{german}{Secondary Bibliography}{Sekundärliteratur}
+%    \end{macrocode}
 % 
 % \iffalse
 
@@ -518,7 +594,18 @@
 %    \begin{macrocode}
 \addbibresource{rub-kunstgeschichte-example.bib}
 %    \end{macrocode}
+% \iffalse
+
+%% Load additional packages
+% \fi
+% To set our language to german (using the new spelling rules) we load \pkg{babel}.
 %
+%    \begin{macrocode}
+\usepackage[ngerman]{babel} % Sets the language of the document
+%    \end{macrocode}
+% \iffalse
+
+% \fi
 % Having finished the preamble, we begin the document, typeset the title and include a table of contents.
 %    \begin{macrocode}
 \begin{document}
@@ -552,6 +639,8 @@
     is automatically loaded to enable clickable
     links and references.
 
+    We use the \texttt{babel} package to set the language to german (even though this example document is actually written in english) to showcase how headings are automatically translated.
+
     \section{How to cite sources}
     This class automatically loads the \texttt{biblatex} package
     for sophisticated bibliography and citations.
@@ -578,7 +667,7 @@
     \autocite{biblatexCheatsheet}.
 
     At the end of the document we can include a bibliography
-    containing all cited sources, divided into primary and secondary literature, with \verb|\printbibliographies|. Primary literature (also called a \textit{source}) is something like the bible\autocite{bible}, letters, treatises etc. We put the bibliography on a new page by using \verb|\clearpage| before printing it.
+    containing all cited sources, divided into primary and secondary literature, with \verb|\printbibliographies|. Primary literature (also called a \textit{source}) is something like the bible\autocite{bible}, letters, treatises etc. We put the bibliography on a new page by using \verb|\clearpage| before printing it. Note, that since we used \verb|\usepackage[ngerman]{babel}| in the preamble, the headings of the bibliography are typed in german.
 
     \clearpage
     \printbibliographies


### PR DESCRIPTION
Provides a command to print bibliographies divided into primary and secondary sources as requested in #37.

Also provides translation capabilities for multi-lingual strings.